### PR TITLE
feat: add author image in blog roll using GatsbyImage component

### DIFF
--- a/src/components/BlogRoll.js
+++ b/src/components/BlogRoll.js
@@ -5,10 +5,15 @@ import Button from "./Buttons/Button"
 import { navigate } from "gatsby"
 // import { GatsbyImage, getImage } from "gatsby-plugin-image"
 import "../sass/components/_blogroll.scss"
+import {useAuthors} from '../hooks/useAuthors';
+import {GatsbyImage} from 'gatsby-plugin-image';
 
 function BlogRoll({ count }) {
-  var posts = []
+  let posts = []
   const postsQueried = useBlogRoll()
+  // EXPLANATION: just calling the result of useAuthors and assigning it to an "authors" variable
+  const authors = useAuthors()
+
   //This hardcopy operation is needed specifically because the component is being used w. different {count} parameters
   //Since the static query runs only once, we query all posts
   //and slice the array of posts on render time
@@ -17,14 +22,18 @@ function BlogRoll({ count }) {
     posts.length = Math.min(posts.length, count)
   }
 
-  console.log(posts)
-
   return (
     <>
       <div className="row">
         <div className="col">
           {posts &&
             postsQueried.map(post => {
+              /* EXPLANATION: aking advantage of the loop (because we are looping through the posts) and you are getting the exact data for each post ("post" as the iterable variable)
+                 and having all authors, you just need to find which author of the post (post.frontmatter.author) is the same as the author.name (author.name is the name of the author) because the other node holds the image data (and other)
+              * */
+              const currentAuthor = authors.find(author => author.name === post.frontmatter.author)
+
+              
               const link = Object.entries(post)[1][1].slug
 
               const timeToRead = Math.ceil(
@@ -41,6 +50,8 @@ function BlogRoll({ count }) {
                 <div className="mt-40px mb-40px" key={post.frontmatter.title}>
                   <div className="blog-card">
                     <div className="blog-card-header">
+                      {/*EXPLANATION: just calling the GatsbyImage and passing the needed data*/}
+                      <GatsbyImage alt={author} image={currentAuthor.authorimage.childImageSharp.gatsbyImageData}/>
                       <p>{author}</p>
                       <div className="blog-card-header-separator"></div>
 

--- a/src/hooks/useAuthors.js
+++ b/src/hooks/useAuthors.js
@@ -1,0 +1,32 @@
+import { useStaticQuery, graphql } from "gatsby"
+
+/* Explanation: I all the authors in a separate static Query. Why? Because I think it separates concerns and logics.
+ In that way, you can reuse and get the authors from anywhere in the app. If I put this query in the useBlogRollQuery.js, I'm sticking business logic meaning
+ that always I get all the blogs, I also get the authors. If this is ALWAYS what you need, you can combine them but either way you can still calling both hooks if needed to combine
+*/
+export const useAuthors = () => {
+  const data = useStaticQuery(
+    graphql`
+      query getAuthors {
+          allAuthorsJson {
+              nodes {
+                  authorimage {
+                      childImageSharp {
+                          gatsbyImageData
+                      }
+                  }
+                  shortbio
+                  name
+                  email
+              }
+          }
+      }
+    `
+  )
+  /* EXPLANATION: we just return from data the allAuthorsJson (is the node name we are querying) and from there, the nodes (the array of authors).
+   This means that when we are calling useAuthors() we will get an array of authors (data.allAuthorsJson.nodes)
+  */
+  return data.allAuthorsJson.nodes
+
+}
+

--- a/src/hooks/useBlogRollQuery.js
+++ b/src/hooks/useBlogRollQuery.js
@@ -13,7 +13,6 @@ export const useBlogRoll = () => {
                 minutes
               }
             }
-
             frontmatter {
               date(formatString: "YYYY. MM. DD.")
               description


### PR DESCRIPTION
Hi István!

As promised, I've added the author's image to the blog roll and made some explanations in the comments. But can be summarized in:

- Query the author's data (`allAuthorsJson`) using a `useStaticQuery` hook. It's an implementation decision to put it in a separate query or merge them. I've decided to use a separate one to isolate concerns and responsibilities
- Call the hook where you need it (blog roll in this case)
- Taking advantage of that you are already looping through all the posts to display them in a roll, you know in each iteration of the loop which is the current post, so you know the `author`, `title`, etc. You only need to find, among all authors, which one matches the current post, so in the end, which one is the current author, that holds all the information that is not the responsibility of the post (author image, short bio, etc.)

Here's a screenshot of the result (I have a wide screen)

![image](https://user-images.githubusercontent.com/14785182/208845597-86f45bdb-77dc-4c97-88f6-139abbff19e0.png)

Now it's up to you to style them. We can cover the stylish part in further sessions if you want as well.


Happy holidays and happy new year! It was great to know your kid 😄 

<img src="https://media.giphy.com/media/l4JyUETLG4i0jTCH6/giphy-downsized.gif" />