### PR TITLE
feat: add buy now button

### DIFF
--- a/src/components/Blog/blogPost.js
+++ b/src/components/Blog/blogPost.js
@@ -28,8 +28,6 @@ const BlogPost = ({ data, children, pageContext, location }) => {
   const sectionRef = useRef(null)
   useEffect(() => setArticleProperties(sectionRef.current), [])
 
-  console.log(post)
-
   return (
     <Layout articleProperties={articleProperties}>
       <div className="blog-posts-wrapper">

--- a/src/components/Events/EventsFeaturedRoll.js
+++ b/src/components/Events/EventsFeaturedRoll.js
@@ -49,7 +49,6 @@ export default function EventsFeaturedRoll({
             )
           }
 
-          console.log(eventlink)
           return (
             <div className="col-12-xs col-6-md col-4-xl" key={date}>
               <div className="event-card">

--- a/src/components/Shopify/product.js
+++ b/src/components/Shopify/product.js
@@ -15,25 +15,22 @@ import { element } from "prop-types"
 
 const ProductTemplate = ({ pageContext }) => {
   const { product } = pageContext
-  // const bind = useInput(1)
-  const { addVariantToCart, cart, removeLineItems, checkout } = useStore()
+  const { addVariantToCart, cart, removeCart, addNewVariantToCart } = useStore()
   const [amount, setAmount] = useState(1)
   const [modalOpen, setModalOpen] = useState(false)
-  const setDecrease = () => {
-    amount > 1 ? setAmount(amount - 1) : setAmount(1)
-  }
-  const setIncrease = () => {
-    setAmount(amount + 1)
+  const setDecrease = () => amount > 1 ? setAmount(amount - 1) : setAmount(1)
+  const setIncrease = () => setAmount(amount + 1)
+  const openModal = () => setModalOpen(true)
+  const closeModal = () => setModalOpen(false)
+
+  const handleBuyNow = async () => {
+    const cart = await removeCart()
+
+    const checkout = await addNewVariantToCart(cart, product, amount)
+    window.open(checkout.webUrl)
   }
 
-  const openModal = () => {
-    setModalOpen(true)
-  }
-
-  const closeModal = () => {
-    setModalOpen(false)
-  }
-
+console.log("cart in view", cart)
   return (
     <Layout>
       <Seo title={product.title} />
@@ -90,11 +87,7 @@ const ProductTemplate = ({ pageContext }) => {
               <Button
                 type="button"
                 buttonStyle="btn--primary--solid--full"
-                onClick={async () => {
-                  await removeLineItems()
-                  await addVariantToCart(product, amount)
-                  window.open(checkout.webUrl)
-                }}
+                onClick={handleBuyNow}
               >
                 Buy it now
               </Button>

--- a/src/pages/cart.js
+++ b/src/pages/cart.js
@@ -21,8 +21,6 @@ const Cart = () => {
     return totalPrice
   }, 0)
 
-  console.log("Total cart price:", total)
-
   return (
     <Layout>
       <Seo title="KOSÁR" />


### PR DESCRIPTION
Hi István!

I fixed the "Buy now" button:

## The problem

The underlying problem is about contexts. The code was working as supposed but, having in mind that the `onClick` button did:

```js
  const handleBuyNow = async () => {
    await removeCart()
    await addVariantToCart(product, amount)
    window.open(checkout.webUrl)
  }
```

The problem was that about contexts as I said. `removeCart` was executed properly and removed the elements in the cart as we saw. However, calling just right after the `addVariantToCart` didn't update the `cart` in the scope of the function, so it was set as `[]` from the `removeCart` and filled again by `addVariantToCart` since the internal `cart` of the `addVariantToCart` function was already filled with the previous elements.

## The Fix:
Simply return the values that we expect to be used in the functions:

```js
  const handleBuyNow = async () => {
    const cart = await removeCart()
    const checkout = await addNewVariantToCart(cart, product, amount)
    window.open(checkout.webUrl)
  }
```
In this new scope, `cart` and `checkout` always have the updated value.

Test it and let me know if there's something to address in Monday's session.

Have a great weekend.


P.S: the code can be simplified and removed duplicities but for now it will do the trick

